### PR TITLE
Update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,47 @@ When adding a dependency, verify the package and maintainer to avoid typosquatte
 - Limit line length to around 100 characters for readability.
 - Write clear comments for complex logic and keep stateful code in hooks or contexts.
 
+## Next.js patterns
+- Default to server components. Add `"use client"` at the top of a file only when
+  browser APIs or React state are required.
+- Export `metadata` from each `page.tsx` to manage SEO tags and sharing cards.
+- Keep route directories under `app/` with their own `page.tsx` and optional
+  `layout.tsx` for nested layouts.
+- Place API handlers in `app/api/<route>/route.ts`.
+- Use `next/dynamic` to lazily load heavy client components.
+
+## React patterns
+- Use functional components with typed props.
+- Extract reusable logic into hooks under `hooks/` and prefix them with `use`.
+- Store cross-cutting state in context providers under `contexts/`.
+- Name components with `PascalCase`; name hooks in `camelCase` with a `use`
+  prefix.
+- Clean up side effects in the return function of `useEffect`.
+
+## File structure
+- Organize route folders under `app/<segment>` with a `page.tsx` and optional
+  `layout.tsx`.
+- Keep shared building blocks in `components/shared`.
+- Group feature components under `components/<feature>`. When a component grows
+  beyond a single file, place it in its own directory:
+
+  ```
+  components/<feature>/<ComponentName>/
+    index.tsx
+    types.ts          # optional
+    styles.ts         # or styles.module.css
+  ```
+
+- Re-export components from `components/<feature>/index.ts` so import paths stay
+  short.
+- Store helper functions in `utils/` and shared types in `types/`.
+- `app/globals.css` should only import Tailwind layers and minimal overrides.
+  Rely on Tailwind utility classes for most styling instead of large global CSS.
+
+## Commit and testing
+- Always run `pnpm lint` and `pnpm build` before committing changes.
+- Use descriptive commit messages so history is easy to follow.
+
 ## AI tools
 - **Cursor, Copilot, Claude** or other agents should follow these guidelines.
 - Provide clear commit messages and keep related changes in a single commit.


### PR DESCRIPTION
## Summary
- clarify that global styles only import Tailwind layers and overrides

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_68707d164b84832b9dfc086fc17bbe44